### PR TITLE
Relax construct version bounds again

### DIFF
--- a/ledgerwallet/params.py
+++ b/ledgerwallet/params.py
@@ -19,7 +19,6 @@ from construct import (
 )
 from construct.core import (
     byte2int,
-    iterateints,
     singleton,
     stream_read,
     stream_write,
@@ -40,7 +39,7 @@ class Asn1Length(Construct):
         num_bytes = byte & ~0x80
         encoded_len = stream_read(stream, num_bytes, path)
         num = 0
-        for len_byte in iterateints(encoded_len):
+        for len_byte in encoded_len:
             num = num << 8 + len_byte
         return num
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "click>=7.0",
-        "construct==2.10.61",
+        "construct>=2.10",
         "cryptography>=2.5",
         "ecdsa",
         "hidapi",


### PR DESCRIPTION
`iterints` is actual trivial: https://github.com/construct/construct/commit/8915512f53552b1493afdbce5bbf8bb6f2aa4411#diff-51115802926a071de160de5506d64046f1acefcad6d6df20dfdd6d08c3c6ded4L36-L38