### PR TITLE
Add instructions to install from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Under a Debian or Ubuntu based system, compiling HIDAPI requires to install addi
 sudo apt install python3-dev libusb-1.0-0-dev libudev-dev
 ```
 
+### Install from source
+
+```shell
+git clone https://github.com/LedgerHQ/ledgerctl.git
+pip3 install --upgrade protobuf setuptools ecdsa
+cd ledgerctl
+pip install -e .
+```
+
 ### Device configuration
 
 You should install a custom certificate authority (CA) on the device to make the usage of ledgerctl easier. This certificate is used to establish a custom secure channel between the computer and the device, and identifies ledgerctl as a "trusted manager" on the device.


### PR DESCRIPTION
The quick install instructions use the remote tag `0.1.2`, which doesn't work due to #17. Add instructions to install from a local checkout.