### PR TITLE
Fix typo: 'send_certicate_chain' -> 'send_certificate_chain'

### DIFF
--- a/ledgerwallet/client.py
+++ b/ledgerwallet/client.py
@@ -262,7 +262,7 @@ class LedgerClient(object):
             if len(certificate) == 0:
                 break
             client_chain.append(certificate)
-        server.send_certicate_chain(client_chain)
+        server.send_certificate_chain(client_chain)
 
         # Mutual authentication done, retrieve shared secret
         self.apdu_exchange(LedgerIns.MUTUAL_AUTHENTICATE)

--- a/ledgerwallet/hsmserver.py
+++ b/ledgerwallet/hsmserver.py
@@ -73,6 +73,6 @@ class HsmServer(LedgerServer):
         public_key = self.public_key
         return [serialize(public_key) + serialize(server_signature)]
 
-    def send_certicate_chain(self, chain):
+    def send_certificate_chain(self, chain):
         for certificate in chain:
             self.query(certificate)

--- a/ledgerwallet/ledgerserver.py
+++ b/ledgerwallet/ledgerserver.py
@@ -15,7 +15,7 @@ class LedgerServer(ABC):
         pass
 
     @abstractmethod
-    def send_certicate_chain(self, chain):
+    def send_certificate_chain(self, chain):
         pass
 
     def get_shared_secret(self):

--- a/ledgerwallet/simpleserver.py
+++ b/ledgerwallet/simpleserver.py
@@ -49,7 +49,7 @@ class SimpleServer(LedgerServer):
 
         return cert_chain
 
-    def send_certicate_chain(self, chain):
+    def send_certificate_chain(self, chain):
         assert len(chain) == 2
 
         last_dev_pub_key = PublicKey(self.master_public)


### PR DESCRIPTION
Fix a small typo so the spell checker stops complaining!