### PR TITLE
Update protobuf to at least 3.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="ledgerwallet",
     version=get_version("ledgerwallet/__init__.py"),
     url="https://github.com/LedgerHQ/ledgerctl/",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     license="MIT",
     description="Python client and library to communicate with Ledger devices",
     long_description=long_description,
@@ -49,7 +49,6 @@ setup(
     py_modules=["ledgerctl"],
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "hidapi",
         "intelhex",
         "Pillow",
-        "protobuf>=3.6",
+        "protobuf>=3.20",
         "requests",
         "tabulate",
     ],


### PR DESCRIPTION
Protobuf 3.20 is not backward-compatible, as explained in https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0 . As commit 01c663932a10 ("Generate pb2 code with recent protoc") updated the protobuf files, the dependency also needs to be bumped:

> [Breaking change] Protobuf python generated codes are simplified. Descriptors and message
> classes' definitions are now dynamic created in internal/builder.py.
> Insertion Points for messages classes are discarded.