### PR TITLE
Describe 0x661E error when installing a custom certificate

### DIFF
--- a/ledgerctl.py
+++ b/ledgerctl.py
@@ -231,6 +231,8 @@ def install_ca(get_client, name, public_key):
             click.echo("A certificate is already installed on the device.")
         elif e.sw == 0x6802:  # INVALID_PARAMETER
             click.echo("The provided certificate is invalid.")
+        elif e.sw == 0x661E:
+            click.echo("The device is not in recovery mode.")
         else:
             raise
 


### PR DESCRIPTION
When `ledgerctl install-ca` is used on a device not booted in Recovery Mode, an error 0x661E is received. Describe this error properly to help users know what they did wrong.

This has been tested with a Ledger Nano S+ device.