### PR TITLE
[update] Click >= 7.0 to >= 8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        "click>=7.0",
+        "click>=8.0",
         "construct>=2.10",
         "cryptography>=2.5",
         "ecdsa",


### PR DESCRIPTION
For some reason, when installed through a dependency (like `ragger` -> `ledgerwallet` -> `click`), `pip` does not update `click` to a newer version, it stays at `7.0`.
This triggers an conflict with other python packages such as `speculos`, which uses `flask`, which itself needs `click>=8.0`.

I'm baffled that `pip` can't update this package by itself (`speculos` does explicit the version of `flask`, and so does `flask` with `click`), but here I am, asking for a version bump, so that my CIs (`ragger`, `app-exchange`) won't fail on such lousy issue.