### PR TITLE
Add context manager to open device

### DIFF
--- a/ledgerwallet/transport/__init__.py
+++ b/ledgerwallet/transport/__init__.py
@@ -1,3 +1,4 @@
+from .device import Device
 from .hid import HidDevice
 from .tcp import TcpDevice
 
@@ -9,3 +10,17 @@ def enumerate_devices():
     for cls in DEVICE_CLASSES:
         devices.extend(cls.enumerate_devices())
     return devices
+
+
+class open_device:
+    """Open a device in a context manager."""
+
+    def __init__(self, device: Device):
+        self.device = device
+
+    def __enter__(self):
+        self.device.open()
+        return self.device
+
+    def __exit__(self, *exc_details):
+        self.device.close()

--- a/ledgerwallet/transport/__init__.py
+++ b/ledgerwallet/transport/__init__.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from .device import Device
 from .hid import HidDevice
 from .tcp import TcpDevice
@@ -12,15 +14,11 @@ def enumerate_devices():
     return devices
 
 
-class open_device:
+@contextmanager
+def open_device(dev: Device):
     """Open a device in a context manager."""
-
-    def __init__(self, device: Device):
-        self.device = device
-
-    def __enter__(self):
-        self.device.open()
-        return self.device
-
-    def __exit__(self, *exc_details):
-        self.device.close()
+    try:
+        dev.open()
+        yield dev
+    finally:
+        dev.close()

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -1,0 +1,36 @@
+from ledgerwallet.transport import open_device
+from ledgerwallet.transport.device import Device
+
+
+class MockDevice(Device):
+    @classmethod
+    def enumerate_devices(cls):
+        """Do nothing."""
+
+    def __init__(self):
+        self.is_open = False
+
+    def open(self):
+        self.is_open = True
+
+    def write(self, data: bytes):
+        """Do nothing."""
+
+    def read(self, timeout: int = 0) -> bytes:
+        """Do nothing."""
+
+    def exchange(self, data: bytes, timeout: int = 0) -> bytes:
+        """Do nothing."""
+
+    def close(self):
+        self.is_open = False
+
+
+def test_context_manager():
+    dev = MockDevice()
+    assert not dev.is_open
+
+    with open_device(dev):
+        assert dev.is_open
+
+    assert not dev.is_open


### PR DESCRIPTION
This PR adds a context manager to open a device, it would allow the use of the following pattern:

```python
with open_device(device):
    device.exchange(...)
```

instead of:

```python
try:
    device.open()
    device.exchange(...)
finally:
    device.close()
```