### PR TITLE
Handle new 'apiLevel' tag

### DIFF
--- a/ledgerwallet/client.py
+++ b/ledgerwallet/client.py
@@ -313,9 +313,20 @@ class LedgerClient(object):
         params = app_manifest.serialize_parameters()
         main_address = hex_file.start_addr["EIP"] - hex_file.minaddr()
 
-        data = struct.pack(
-            ">IIIII", code_length, data_length, len(params), flags, main_address
-        )
+        if app_manifest.has_api_level():
+            data = struct.pack(
+                ">BIIIII",
+                app_manifest.get_api_level(),
+                code_length,
+                data_length,
+                len(params),
+                flags,
+                main_address,
+            )
+        else:
+            data = struct.pack(
+                ">IIIII", code_length, data_length, len(params), flags, main_address
+            )
         self.apdu_secure_exchange(LedgerSecureIns.CREATE_APP, data)
 
         hex_file.puts(hex_file.maxaddr() + 1, params)

--- a/ledgerwallet/manifest.py
+++ b/ledgerwallet/manifest.py
@@ -123,11 +123,17 @@ class AppManifest(object):
         else:
             return int(self.json["flags"], 16)
 
+    def get_api_level(self) -> int:
+        return int(self.json["apiLevel"], 10)
+
     def get_binary(self) -> str:
         return os.path.join(self.path, self.json["binary"])
 
     def get_target_id(self) -> int:
         return int(self.json["targetId"], 16)
+
+    def has_api_level(self) -> bool:
+        return self.json.get("apiLevel") is not None
 
     def serialize_parameters(self) -> bytes:
         parameters = []


### PR DESCRIPTION
An upcoming update will introduce a new `apiLevel` tag. This PR adds the necessary changes to handle that flag, and also keep it compatible with previous versions, as will be the case for `ledgerblue`.