### PR TITLE
[release] 0.2.2

### DIFF
--- a/ledgerwallet/__init__.py
+++ b/ledgerwallet/__init__.py
@@ -1,3 +1,3 @@
 """Python client and library to communicate with Ledger devices."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.2"


### PR DESCRIPTION
Current version available on `test.pypi.org` is 0.2.1, so as published version can not be overridden or deleted, I'm bumping the version just after so that the current code will be deployed.

**>> DO NOT MERGE BEFORE THE USER 'LEDGER' IS OWNER OF THE TEST.PYPI.ORG REPO <<**