### PR TITLE
Add an offline mode for install and delete

### DIFF
--- a/ledgerwallet/transport/file.py
+++ b/ledgerwallet/transport/file.py
@@ -1,0 +1,25 @@
+from .device import Device
+
+
+class FileDevice(Device):
+    def __init__(self):
+        pass
+
+    def enumerate_devices(self, cls):
+        return FileDevice()
+
+    def open(self):
+        pass
+
+    def write(self, data: bytes):
+        print(data.hex())
+
+    def read(self, timeout: int = 0) -> bytes:
+        return b"\x00\x00\x00\x02\x90\x00"
+
+    def exchange(self, data: bytes, timeout: int = 0) -> bytes:
+        self.write(data)
+        return self.read()
+
+    def close(self):
+        pass


### PR DESCRIPTION
passing `--offline` to `install`/`delete` command behaves similarly to `ledgerblue` and will not attempt to connect to a device. Instead, it will print out APDU exchanges in the terminal.

This enables `ledgerctl` to handle final parts of app deployments, that require generation of an APDU file.