### PR TITLE
improve doc of command delete-ca

### DIFF
--- a/ledgerwallet/ledgerctl.py
+++ b/ledgerwallet/ledgerctl.py
@@ -273,7 +273,7 @@ def install_ca(get_client, name, public_key):
             raise
 
 
-@cli.command(help="Delete custom certificate authority.")
+@cli.command(help="Delete custom certificate authority (requires recovery mode).")
 @click.pass_obj
 def delete_ca(get_client):
     try:


### PR DESCRIPTION
Problem: I lost of a lot of time before realizing that command "delete-ca" requires recovery mode.

This PR fixes this by improving documentation.