### PR TITLE
Add 'offline' option to ledgerctl CLI install command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-12-06
+
+### Add
+
+- offline mode : Add an option to allow dumping the APDU installation / delete file instead of trying to send it to a device.
+
 ## [0.3.0] - 2023-05-29
 
 ### Changed

--- a/ledgerwallet/crypto/scp.py
+++ b/ledgerwallet/crypto/scp.py
@@ -112,3 +112,18 @@ class SCP(object):
             raise Exception("Invalid SCP MAC")
         data = self._decrypt_data(encrypted_data)
         return iso9797_unpad(data)
+
+
+class FakeSCP:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def identity_wrap(data: bytes) -> bytes:
+        return data
+
+    def wrap(self, data):
+        return self.identity_wrap(data)
+
+    def unwrap(self, data):
+        return self.identity_wrap(data)

--- a/ledgerwallet/ledgerctl.py
+++ b/ledgerwallet/ledgerctl.py
@@ -172,14 +172,14 @@ def list_apps(get_client, remote, url, key):
     is_flag=True,
 )
 @click.option(
-    "-d",
-    "--dump",
-    help="Dump APDU installation file.",
+    "-o",
+    "--offline",
+    help="Dump APDU installation file, do not attempt to connect to a physical device.",
     is_flag=False,
     flag_value="out.apdu",
 )
 @click.pass_obj
-def install_app(get_client, manifest: AppManifest, force, dump):
+def install_app(get_client, manifest: AppManifest, force, offline):
     try:
         app_manifest: AppManifest = AppManifestToml(manifest)
     except TOMLDecodeError as toml_error:
@@ -192,13 +192,13 @@ def install_app(get_client, manifest: AppManifest, force, dump):
             raise ManifestFormatError(toml_error, json_error)
 
     try:
-        if dump:
+        if offline:
             try:
-                dump_file = open(dump, "w")
+                dump_file = open(offline, "w")
             except OSError:
-                click.echo("Unable to open file {} for dump.".format(dump))
+                click.echo("Unable to open file {} for dump.".format(offline))
                 sys.exit(1)
-            click.echo("Dumping APDU installation file to {}".format(dump))
+            click.echo("Dumping APDU installation file to {}".format(offline))
             client = get_file_device(dump_file, app_manifest.target_id)
         else:
             client = get_client()
@@ -236,26 +236,28 @@ def install_remote_app(get_client, app_path, key_path, url, key):
     is_flag=True,
 )
 @click.option(
-    "-d",
-    "--dump",
-    help="Dump APDU delete command file.",
+    "-o",
+    "--offline",
+    help=(
+        "Dump APDU delete command file, do not attempt to connect to a physical device."
+    ),
     is_flag=False,
     flag_value="out_delete.apdu",
 )
 @click.pass_obj
-def delete_app(get_client, app, by_hash, dump):
+def delete_app(get_client, app, by_hash, offline):
     if by_hash:
         data = bytes.fromhex(app)
     else:
         data = app
 
-    if dump:
+    if offline:
         try:
-            dump_file = open(dump, "w")
+            dump_file = open(offline, "w")
         except OSError:
-            click.echo("Unable to open file {} for dump.".format(dump))
+            click.echo("Unable to open file {} for dump.".format(offline))
             sys.exit(1)
-        click.echo("Dumping APDU delete command file to {}".format(dump))
+        click.echo("Dumping APDU delete command file to {}".format(offline))
         client = get_file_device(dump_file)
     else:
         client = get_client()

--- a/ledgerwallet/ledgerctl.py
+++ b/ledgerwallet/ledgerctl.py
@@ -168,7 +168,7 @@ def list_apps(get_client, remote, url, key):
 @click.option(
     "-f",
     "--force",
-    help="Delete using application hash instead of application name",
+    help="Delete the app with the same name before loading the provided one.",
     is_flag=True,
 )
 @click.option(

--- a/ledgerwallet/ledgerctl.py
+++ b/ledgerwallet/ledgerctl.py
@@ -200,6 +200,8 @@ def install_app(get_client, manifest: AppManifest, force, offline):
                 sys.exit(1)
             click.echo("Dumping APDU installation file to {}".format(offline))
             client = get_file_device(dump_file, app_manifest.target_id)
+            if force:
+                client.delete_app(app_manifest.app_name)
         else:
             client = get_client()
             if force:

--- a/ledgerwallet/manifest.py
+++ b/ledgerwallet/manifest.py
@@ -105,6 +105,10 @@ class AppManifest(ABC):
     def app_name(self) -> str:
         return self.dic.get("name", "")
 
+    @property
+    def target_id(self) -> str:
+        return self.dic.get("targetId", "")
+
     @abstractmethod
     def data_size(self, device: str) -> int:
         pass

--- a/ledgerwallet/transport/__init__.py
+++ b/ledgerwallet/transport/__init__.py
@@ -1,10 +1,15 @@
 from contextlib import contextmanager
 
 from .device import Device
+from .file import FileDevice
 from .hid import HidDevice
 from .tcp import TcpDevice
 
 DEVICE_CLASSES = [TcpDevice, HidDevice]
+
+__all__ = [
+    "FileDevice",
+]
 
 
 def enumerate_devices():

--- a/ledgerwallet/transport/file.py
+++ b/ledgerwallet/transport/file.py
@@ -1,0 +1,41 @@
+import sys
+
+from ..utils import LedgerIns, VersionInfo
+from .device import Device
+
+
+class FileDevice(Device):
+    def __init__(self, target_id, out=None):
+        if out is None:
+            out = sys.stdout
+        t_id = int(target_id, 16)
+        self.version_info = VersionInfo.build(
+            dict(target_id=t_id, se_version="0", flags=0, mcu_version="0")
+        )
+        self.buffer = None
+        self.out = out
+
+    @classmethod
+    def enumerate_devices(cls):
+        return None
+
+    def open(self):
+        pass
+
+    def write(self, data: bytes):
+        self.buffer = data
+        if not self.buffer[1] == LedgerIns.GET_VERSION:
+            print(data.hex(), file=self.out)
+
+    def read(self, timeout: int = 0) -> bytes:
+        if self.buffer[1] == LedgerIns.GET_VERSION:
+            return self.version_info + b"\x90\x00"
+        return b"\x00\x00\x00\x02\x90\x00"
+
+    def exchange(self, data: bytes, timeout: int = 0) -> bytes:
+        self.write(data)
+        return self.read()
+
+    def close(self):
+        if self.out:
+            self.out.close()

--- a/ledgerwallet/utils.py
+++ b/ledgerwallet/utils.py
@@ -1,5 +1,18 @@
 import logging
-from enum import Enum
+from enum import Enum, IntEnum
+
+from construct import (
+    Bytes,
+    Const,
+    FlagsEnum,
+    Hex,
+    Int8ub,
+    Int32ub,
+    Int32ul,
+    Optional,
+    PascalString,
+    Struct,
+)
 
 
 class DeviceNames(Enum):
@@ -7,6 +20,58 @@ class DeviceNames(Enum):
     LEDGER_NANO_X = "Ledger Nano X"
     LEDGER_NANO_SP = "Ledger Nano S+"
     LEDGER_BLUE = "Ledger Blue"
+
+
+class LedgerIns(IntEnum):
+    SECUINS = 0
+    GET_VERSION = 1
+    VALIDATE_TARGET_ID = 4
+    INITIALIZE_AUTHENTICATION = 0x50
+    VALIDATE_CERTIFICATE = 0x51
+    GET_CERTIFICATE = 0x52
+    MUTUAL_AUTHENTICATE = 0x53
+    ONBOARD = 0xD0
+    RUN_APP = 0xD8
+    # Commands for custom endorsement
+    ENDORSE_SET_START = 0xC0
+    ENDORSE_SET_COMMIT = 0xC2
+
+
+class LedgerSecureIns(IntEnum):
+    SET_LOAD_OFFSET = 5
+    LOAD = 6
+    FLUSH = 7
+    CRC = 8
+    COMMIT = 9
+    CREATE_APP = 11
+    DELETE_APP = 12
+    LIST_APPS = 14
+    LIST_APPS_CONTINUE = 15
+    GET_VERSION = 16
+    GET_MEMORY_INFORMATION = 17
+    SETUP_CUSTOM_CERTIFICATE = 18
+    RESET_CUSTOM_CERTIFICATE = 19
+    DELETE_APP_BY_HASH = 21
+    MCU_BOOTLOADER = 0xB0
+
+
+VersionInfo = Struct(
+    target_id=Hex(Int32ub),
+    se_version=PascalString(Int8ub, "utf-8"),
+    _flags_len=Const(b"\x04"),
+    flags=FlagsEnum(
+        Int32ul,
+        recovery_mode=1,
+        signed_mcu=2,
+        is_onboarded=4,
+        trust_issuer=8,
+        trust_custom_ca=16,
+        hsm_initialized=32,
+        pin_validated=128,
+    ),
+    mcu_version=PascalString(Int8ub, "utf-8"),
+    mcu_hash=Optional(Bytes(32)),
+)
 
 
 def enable_apdu_log():


### PR DESCRIPTION
Add `--offline` option to the `install` CLI command to dump the APDU file instead of trying to install it to a physical device. 

The target id is extracted from the manifest.

### For rust apps

Next steps : 
* update app builder image with ledgerctl installation https://github.com/LedgerHQ/ledger-app-builder/pull/91
* call `ledgerctl install --offline myfile --manifest mymanifest` from `cargo-ledger` when the build command is invoked to generate the apdu file automatically.  https://github.com/LedgerHQ/cargo-ledger/pull/31