### PR TITLE
Add support of dashboard icons for Stax and Flex when installing apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-05-22
+
+### Add
+
+- Support for Stax and Flex dashboard icon generation when installing apps.
+
 ## [0.4.0] - 2023-12-06
 
 ### Add

--- a/ledgerwallet/manifest_json.py
+++ b/ledgerwallet/manifest_json.py
@@ -37,7 +37,7 @@ class AppManifestJson(AppManifest):
                 parameters.append({"type_": "BOLOS_TAG_APPVERSION", "value": value})
             elif entry == "icon":
                 parameters.append(
-                    {"type_": "BOLOS_TAG_ICON", "value": icon_from_file(value)}
+                    {"type_": "BOLOS_TAG_ICON", "value": icon_from_file(value, device)}
                 )
             elif entry == "derivationPath":
                 derivation_paths = self.serialize_derivation_path(value)

--- a/ledgerwallet/manifest_toml.py
+++ b/ledgerwallet/manifest_toml.py
@@ -56,7 +56,7 @@ class AppManifestToml(AppManifest):
                         parameters.append(
                             {
                                 "type_": "BOLOS_TAG_ICON",
-                                "value": icon_from_file(device_value),
+                                "value": icon_from_file(device_value, device),
                             }
                         )
                     elif device_entry == "derivationPath":

--- a/ledgerwallet/proto/LedgerHSMServer_pb2.py
+++ b/ledgerwallet/proto/LedgerHSMServer_pb2.py
@@ -11,19 +11,17 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-
-
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15LedgerHSMServer.proto\x12\rbluehsmserver\"7\n\tParameter\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05\x61lias\x18\x02 \x01(\t\x12\r\n\x05local\x18\x03 \x01(\x08\"\xa1\x01\n\x07Request\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\nparameters\x18\x02 \x01(\x0c\x12\x11\n\treference\x18\x03 \x01(\t\x12\x0b\n\x03\x65lf\x18\x04 \x01(\x0c\x12\r\n\x05\x63lose\x18\x05 \x01(\x08\x12\x12\n\nlargeStack\x18\x06 \x01(\x08\x12\x33\n\x11remote_parameters\x18\x07 \x03(\x0b\x32\x18.bluehsmserver.Parameter\"L\n\x08Response\x12\n\n\x02id\x18\x01 \x01(\t\x12\x10\n\x08response\x18\x02 \x01(\x0c\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x11\n\texception\x18\x04 \x01(\tb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'LedgerHSMServer_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
-  DESCRIPTOR._options = None
-  _PARAMETER._serialized_start=40
-  _PARAMETER._serialized_end=95
-  _REQUEST._serialized_start=98
-  _REQUEST._serialized_end=259
-  _RESPONSE._serialized_start=261
-  _RESPONSE._serialized_end=337
+    DESCRIPTOR._options = None
+    _PARAMETER._serialized_start = 40
+    _PARAMETER._serialized_end = 95
+    _REQUEST._serialized_start = 98
+    _REQUEST._serialized_end = 259
+    _RESPONSE._serialized_start = 261
+    _RESPONSE._serialized_end = 337
 # @@protoc_insertion_point(module_scope)

--- a/ledgerwallet/proto/listApps_pb2.py
+++ b/ledgerwallet/proto/listApps_pb2.py
@@ -11,17 +11,16 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0elistApps.proto\x12\x08listapps\"F\n\x03\x41pp\x12\r\n\x05\x66lags\x18\x01 \x01(\r\x12\x0c\n\x04hash\x18\x02 \x01(\x0c\x12\x14\n\x0chashCodeData\x18\x03 \x01(\x0c\x12\x0c\n\x04name\x18\x04 \x01(\t\"&\n\x07\x41ppList\x12\x1b\n\x04list\x18\x01 \x03(\x0b\x32\r.listapps.Appb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x0elistApps.proto\x12\x08listapps\"F\n\x03\x41pp\x12\r\n\x05\x66lags\x18\x01 \x01(\r\x12\x0c\n\x04hash\x18\x02 \x01(\x0c\x12\x14\n\x0chashCodeData\x18\x03 \x01(\x0c\x12\x0c\n\x04name\x18\x04 \x01(\t\"&\n\x07\x41ppList\x12\x1b\n\x04list\x18\x01 \x03(\x0b\x32\r.listapps.Appb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'listApps_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
-  DESCRIPTOR._options = None
-  _APP._serialized_start=28
-  _APP._serialized_end=98
-  _APPLIST._serialized_start=100
-  _APPLIST._serialized_end=138
+    DESCRIPTOR._options = None
+    _APP._serialized_start = 28
+    _APP._serialized_end = 98
+    _APPLIST._serialized_start = 100
+    _APPLIST._serialized_end = 138
 # @@protoc_insertion_point(module_scope)

--- a/ledgerwallet/utils.py
+++ b/ledgerwallet/utils.py
@@ -20,6 +20,8 @@ class DeviceNames(Enum):
     LEDGER_NANO_X = "Ledger Nano X"
     LEDGER_NANO_SP = "Ledger Nano S+"
     LEDGER_BLUE = "Ledger Blue"
+    LEDGER_STAX = "Ledger Stax"
+    LEDGER_FLEX = "Ledger Flex"
 
 
 class LedgerIns(IntEnum):
@@ -99,6 +101,8 @@ def get_device_name(target_id: int) -> str:
         0x31010004: DeviceNames.LEDGER_BLUE.value,  # firmware version > 2.0
         0x33000004: DeviceNames.LEDGER_NANO_X.value,
         0x33100004: DeviceNames.LEDGER_NANO_SP.value,
+        0x33200004: DeviceNames.LEDGER_STAX.value,
+        0x33300004: DeviceNames.LEDGER_FLEX.value,
     }
     return target_ids.get(target_id, "Unknown device")
 

--- a/tests/unit/test_manifest_ManifestJSON.py
+++ b/tests/unit/test_manifest_ManifestJSON.py
@@ -66,7 +66,8 @@ class ManifestTestJson(TestCase):
         )
         # fmt: on
         with patch(
-            "ledgerwallet.manifest_json.icon_from_file", lambda x: b"\x01\x02\x03\x04"
+            "ledgerwallet.manifest_json.icon_from_file",
+            lambda x, y: b"\x01\x02\x03\x04",
         ):
             result_json = self.json_manifest.serialize_parameters("1234")
         self.assertEqual(result_json, expected)

--- a/tests/unit/test_manifest_ManifestTOML.py
+++ b/tests/unit/test_manifest_ManifestTOML.py
@@ -76,7 +76,8 @@ class ManifestTestToml(TestCase):
         )
         # fmt: on
         with patch(
-            "ledgerwallet.manifest_toml.icon_from_file", lambda x: b"\x01\x02\x03\x04"
+            "ledgerwallet.manifest_toml.icon_from_file",
+            lambda x, y: b"\x01\x02\x03\x04",
         ):
             result_toml = self.toml_manifest.serialize_parameters("1234")
         self.assertEqual(result_toml, expected)


### PR DESCRIPTION
Basically added the glyph generation code from https://github.com/LedgerHQ/ledger-secure-sdk/blob/master/lib_nbgl/tools/icon2glyph.py in `manifest.py`

There was already a code duplication from https://github.com/LedgerHQ/ledger-secure-sdk/blob/master/icon3.py for BAGL icons...

Not ideal (as it creates more code duplication), but it was the easiest/fastest.